### PR TITLE
Add `version` property for backward-compatibility with `distutils.version`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 
 ## Unreleased
-
+- Add `version` property for backward-compatibility with `distutils.version`
 
 ## 2023-10-14 v0.1.0
 - First release

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,3 +8,15 @@ def test_version():
         < Version("1!1.0b1.dev456")
         < Version("1!1.2.rev33+123456")
     )
+
+
+def test_distutils_backward_compatibility():
+    """
+    The `LooseVersion` and `StrictVersion` classes of `distutils.version`
+    had a `version` property, mirroring the `release` property of
+    `packaging.version`.
+
+    This test verifies it is in place.
+    """
+    version = Version("1.0.dev456")
+    assert version.version == (1, 0)

--- a/verlib2/version.py
+++ b/verlib2/version.py
@@ -290,6 +290,13 @@ class Version(_BaseVersion):
         return self._version.release
 
     @property
+    def version(self) -> Tuple[int, ...]:
+        """
+        Return version tuple for backward-compatibility with `distutils.version`.
+        """
+        return self.release
+
+    @property
     def pre(self) -> Optional[Tuple[str, int]]:
         """The pre-release segment of the version.
 


### PR DESCRIPTION
What the title says.

/cc @seut